### PR TITLE
fix(types): Made the option optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export const defaultRebootOptions: IRebootOptions = {
   tableCellPadding: '0.75rem'
 };
 
-export const reboot = (options: IRebootOptions): FlattenSimpleInterpolation => {
+export const reboot = (options?: IRebootOptions): FlattenSimpleInterpolation => {
   const {
     black,
     fontFamilyBase,


### PR DESCRIPTION
I see no reason to pass an empty object if we do not change any default parameters.